### PR TITLE
pin psr/log with ~1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "psr/log": "dev-master"
+        "psr/log": "~1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
psr/log is just an Interface-only library, which I try to diff between tag 1.0.0..master and just coming with some minor documentation related changes.

By the way, upscale our dependency into `psr/log:dev-master` make other else libraries also need to depend on development release, which seems like not a good idea...

Shall we just pin our psr/log dependency into `psr/log:~1.0` so keep case simpler for maintenance?
